### PR TITLE
使用 Qt Widgets 中的托盘图标

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 
 find_package(Qt6 6.5 REQUIRED COMPONENTS Quick)
+find_package(Qt6 6.5 REQUIRED COMPONENTS Widgets)
 
 qt_standard_project_setup(REQUIRES 6.5)
 
@@ -57,6 +58,7 @@ set_target_properties(HeAlarm PROPERTIES
 
 target_link_libraries(HeAlarm
     PRIVATE Qt6::Quick
+    PRIVATE Qt6::Widgets
 )
 
 include(GNUInstallDirs)

--- a/HeAlarm.cpp
+++ b/HeAlarm.cpp
@@ -5,7 +5,6 @@
 
 HeAlarmApp* HeAlarm::s_app = nullptr;
 QQmlApplicationEngine* HeAlarm::s_qmlEngine = nullptr;
-QObject* HeAlarm::s_trayIcon = nullptr;
 AlarmFileManager* HeAlarm::s_alarmFileManager = nullptr;
 AlarmModel* HeAlarm::s_alarmModel = nullptr;
 CoreNotifier* HeAlarm::s_notifier = nullptr;

--- a/HeAlarm.h
+++ b/HeAlarm.h
@@ -21,7 +21,6 @@ public:
 private:
 	static HeAlarmApp* s_app;
 	static QQmlApplicationEngine* s_qmlEngine;
-	static QObject* s_trayIcon;
 	static AlarmFileManager* s_alarmFileManager;
 	static AlarmModel* s_alarmModel;
 	static CoreNotifier* s_notifier;

--- a/HeAlarmApp.cpp
+++ b/HeAlarmApp.cpp
@@ -19,11 +19,10 @@ void HeAlarmApp::init()
 		HeAlarm::s_alarmModel = new AlarmModel;
 		HeAlarm::s_alarmFileManager = new AlarmFileManager(HeAlarm::alarmModel());
 		HeAlarm::s_notifier = new CoreNotifier(HeAlarm::alarmModel());
+		HeAlarm::s_notificationSender = new TrayNotificationSender;
+		connect(HeAlarm::notifier(), &CoreNotifier::alarmTriggered, HeAlarm::s_notificationSender, &TrayNotificationSender::sendNotification);
 		QObject::connect(HeAlarm::qmlEngine(), &QQmlApplicationEngine::objectCreationFailed,
 						 HeAlarm::app(), []() { QCoreApplication::exit(-1); },
 		Qt::QueuedConnection);
 		HeAlarm::qmlEngine()->loadFromModule("HeAlarm", "Main");
-		HeAlarm::s_trayIcon = HeAlarm::qmlEngine()->rootObjects().at(0)->findChild<QObject*>("sysTrayIcon");
-		HeAlarm::s_notificationSender = new TrayNotificationSender(HeAlarm::s_trayIcon);
-		connect(HeAlarm::notifier(), &CoreNotifier::alarmTriggered, HeAlarm::s_notificationSender, &TrayNotificationSender::sendNotification);
 }

--- a/Main.qml
+++ b/Main.qml
@@ -25,9 +25,7 @@ Window {
 				currentIndex: nvgBar.currentIndex
 				onCurrentIndexChanged: nvgBar.currentIndex = currentIndex
 
-				ClockPage {
-
-				}
+				ClockPage {}
 
 				AlarmPage {
 					editPage: editPge
@@ -47,12 +45,5 @@ Window {
 		anchors.fill: parent
 		visible: false
 		onCancled: visible = false
-	}
-
-	Platform.SystemTrayIcon {
-		objectName: "sysTrayIcon"
-		icon.source: "qrc:///res/Logo.png"
-		tooltip: "HeAlarm 0.1.0"
-		visible: true
 	}
 }

--- a/TrayNotificationSender.cpp
+++ b/TrayNotificationSender.cpp
@@ -1,19 +1,19 @@
 #include "TrayNotificationSender.h"
 #include "AlarmData.h"
 #include <QIcon>
+#include <QSystemTrayIcon>
 
-TrayNotificationSender::TrayNotificationSender(QObject* trayIcon, QObject *parent) :
-	QObject{parent},
-	m_trayIcon {trayIcon}
+TrayNotificationSender::TrayNotificationSender(QObject *parent) :
+	QObject{parent}
 {
-
+	m_trayIcon = new QSystemTrayIcon;
+	m_trayIcon->setIcon(QIcon(":/res/Logo.png"));
+	m_trayIcon->setToolTip("HeAlarm 0.1.1");
+	m_trayIcon->show();
 }
 
 void TrayNotificationSender::sendNotification(const QVariant& var)
 {
 	auto alm = var.value<AlarmData>();
-	QMetaObject::invokeMethod(m_trayIcon, "showMessage",
-							  alm.title,
-							  QTime(alm.hour, alm.minute).toString("HH:mm")
-							  );
+	m_trayIcon->showMessage(alm.title, QTime(alm.hour, alm.minute).toString("HH:mm"), m_trayIcon->icon(), 600000);
 }

--- a/TrayNotificationSender.h
+++ b/TrayNotificationSender.h
@@ -1,15 +1,17 @@
 #pragma once
 #include <QObject>
 
+class QSystemTrayIcon;
+
 class TrayNotificationSender : public QObject
 {
 	Q_OBJECT
 private:
 	static constexpr int duration = 600000;
 private:
-	QObject* m_trayIcon;
+	QSystemTrayIcon* m_trayIcon;
 public:
-	explicit TrayNotificationSender(QObject* trayIcon, QObject *parent = nullptr);
+	explicit TrayNotificationSender(QObject *parent = nullptr);
 public slots:
 	void sendNotification(const QVariant& var);
 };


### PR DESCRIPTION
将原本从 QML 中读取托盘图标的方法改为直接使用 Qt Widgets, 写法更加阳间

fixes #16